### PR TITLE
Add Hexane to projects.toml

### DIFF
--- a/content/wiki/projects.toml
+++ b/content/wiki/projects.toml
@@ -354,3 +354,9 @@ name = "Sjoerd's Voxel Engine"
 url = "https://github.com/sjoerdev/voxel-engine"
 source = "https://github.com/sjoerdev/voxel-engine"
 language = ["C#"]
+
+[[projects]]
+name = "Hexane"
+url = "https://voxelphile.com"
+source = "https://github.com/voxelphile/hexane"
+language = ["Rust", "Glsl"]


### PR DESCRIPTION
Hello Longor. I am developing a voxel project and would like to add it to the registry on voxel.wiki.

Here is the link to the source:
https://github.com/voxelphile/hexane

Thanks,
Brynn Brancamp